### PR TITLE
Add a list to block stalkerware

### DIFF
--- a/filters/security/filter_24_StalkerwareIndicators/configuration.json
+++ b/filters/security/filter_24_StalkerwareIndicators/configuration.json
@@ -1,0 +1,15 @@
+{
+  "name": "Stalkerware Indicators List",
+  "description": "Stalkerware indicators of compromise for Android and iOS.",
+  "homepage": "https://github.com/Te-k/stalkerware-indicators",
+  "sources": [
+    {
+      "name": "Stalkerware Indicators List",
+      "source": "https://github.com/Te-k/stalkerware-indicators/blob/master/generated/hosts",
+      "type": "hosts",
+      "transformations": [
+        "Validate"
+      ]
+    }
+  ]
+}

--- a/filters/security/filter_24_StalkerwareIndicators/configuration.json
+++ b/filters/security/filter_24_StalkerwareIndicators/configuration.json
@@ -1,11 +1,11 @@
 {
   "name": "Stalkerware Indicators List",
   "description": "Stalkerware indicators of compromise for Android and iOS.",
-  "homepage": "https://github.com/Te-k/stalkerware-indicators",
+  "homepage": "https://github.com/AssoEchap/stalkerware-indicators",
   "sources": [
     {
       "name": "Stalkerware Indicators List",
-      "source": "https://github.com/Te-k/stalkerware-indicators/blob/master/generated/hosts",
+      "source": "https://github.com/AssoEchap/stalkerware-indicators/blob/master/generated/hosts",
       "type": "hosts",
       "transformations": [
         "Validate"

--- a/filters/security/filter_24_StalkerwareIndicators/metadata.json
+++ b/filters/security/filter_24_StalkerwareIndicators/metadata.json
@@ -1,0 +1,14 @@
+{
+  "filterId": "staklerware_indicators_list",
+  "id": 24,
+  "name": "Stalkerware Indicators List",
+  "description": "Stalkerware indicators of compromise for Android and iOS.",
+  "timeAdded": 1653078597584,
+  "homepage": "https://github.com/Te-k/stalkerware-indicators",
+  "expires": "30 days",
+  "displayNumber": 4,
+  "tags": [
+    "purpose:security",
+    "purpose:privacy"
+  ]
+}

--- a/filters/security/filter_24_StalkerwareIndicators/metadata.json
+++ b/filters/security/filter_24_StalkerwareIndicators/metadata.json
@@ -4,7 +4,7 @@
   "name": "Stalkerware Indicators List",
   "description": "Stalkerware indicators of compromise for Android and iOS.",
   "timeAdded": 1653078597584,
-  "homepage": "https://github.com/Te-k/stalkerware-indicators",
+  "homepage": "https://github.com/AssoEchap/stalkerware-indicators",
   "expires": "30 days",
   "displayNumber": 4,
   "tags": [


### PR DESCRIPTION
This adds a list of domains used by [stalkerware](https://en.wikipedia.org/wiki/Stalkerware) to exfiltrate information, get orders, and be downloaded onto devices.

The list is generated from [IoC]( https://en.wikipedia.org/wiki/Indicator_of_compromise ) maintained by @Te-k, who [is working]( https://twitter.com/tenacioustek ) for [Amnesty Tech]( https://www.amnesty.org/en/tech/ ), as well as by a community of various security researchers and privacy enthusiasts.

It might be interesting to make this list appear in the "Blocked malware/phishing" category, but I don't think it's currently possible.

Cc: @u039b