### PR TITLE
Add Amazon Sweden

### DIFF
--- a/assets/services.json
+++ b/assets/services.json
@@ -60,6 +60,7 @@
         "||amazon.jp^",
         "||amazon.nl^",
         "||amazon.red^",
+        "||amazon.se^",
         "||amazon.sg^",
         "||amazon^",
         "||amazonalexavoxcon.com^",


### PR DESCRIPTION
Add the amazon.se url for Amazon Sweden.