### PR TITLE
Adding block list for Nox

### DIFF
--- a/assets/nox_blocklist
+++ b/assets/nox_blocklist
@@ -1,0 +1,137 @@
+!
+! Title: The Nox Blocklist
+! Description: List of hosts to block all Nox spyware, telemetry, etc
+! Homepage: http://h4rithd.com/
+! Last modified: 2023-03-13T15:52:40.087Z
+!
+! Compiled by @adguard/hostlist-compiler v1.0.12
+!
+!
+! Source name: The Nox blocklist
+! Source: https://gist.github.com/h4rithd/03eef1d1db79abc58a79b7c6961ff54c
+!
+# START HOSTS LIST ### DO NOT EDIT THIS LINE AT ALL ###
+0.0.0.0	8.bignox.com
+0.0.0.0	alog.umeng.com
+0.0.0.0	android.bignox.com
+0.0.0.0	androiden.duapp.com
+0.0.0.0	api.bignox.com
+0.0.0.0	api.mobula.sdk.duapps.com
+0.0.0.0	api-new.bignox.com
+0.0.0.0	api.noxinfluencer.com
+0.0.0.0	app.bignox.com
+0.0.0.0	appcenter-api.bignox.com
+0.0.0.0	app.static.bignox.com
+0.0.0.0	app.test.bignox.com
+0.0.0.0	ar.bignox.com
+0.0.0.0	attitude.applinzi.com
+0.0.0.0	au.umeng.com
+0.0.0.0	bbs.bignox.com
+0.0.0.0	bignox.com
+0.0.0.0	*.bignox.com
+0.0.0.0	bi.noxgroup.com
+0.0.0.0	bi.yeshen.com
+0.0.0.0	cn.bignox.com
+0.0.0.0	common.duapps.com
+0.0.0.0	de.bignox.com
+0.0.0.0	dev.bignox.com
+0.0.0.0	download.bignox.com
+0.0.0.0	en.bignox.com
+0.0.0.0	es.bignox.com
+0.0.0.0	feed.bignox.com
+0.0.0.0	feed-test.bignox.com
+0.0.0.0	fr.bignox.com
+0.0.0.0	game.bignox.com
+0.0.0.0	gift.bignox.com
+0.0.0.0	googleclubstore.com
+0.0.0.0	gray.bignox.com
+0.0.0.0	group.bignox.com
+0.0.0.0	hm.e.shifen.com
+0.0.0.0	hmma.baidu.com
+0.0.0.0	hostmaster@bignox.com
+0.0.0.0	id.bignox.com
+0.0.0.0	image.bignox.com
+0.0.0.0	in.bignox.com
+0.0.0.0	influencer.yeshen.com
+0.0.0.0	info.bignox.com
+0.0.0.0	ios.bignox.com
+0.0.0.0	it.bignox.com
+0.0.0.0	jp.bignox.com
+0.0.0.0	kol.yeshen.com
+0.0.0.0	kr.bignox.com
+0.0.0.0	launcher-us.yeshen.com
+0.0.0.0	launcher.us.yeshen.com
+0.0.0.0	log.bignox.com
+0.0.0.0	mail.bignox.com
+0.0.0.0	mis.bignox.com
+0.0.0.0	mobile.bignox.com
+0.0.0.0	ms.bignox.com
+0.0.0.0	my.bignox.com
+0.0.0.0	news.bignox.com
+0.0.0.0	noxagile.bceapp.com
+0.0.0.0	noxagile.duapp.com
+0.0.0.0	noxgroup.com
+0.0.0.0	nrc.tapas.net
+0.0.0.0	open.bignox.com
+0.0.0.0	operation@bignox.com
+0.0.0.0	passport.bignox.com
+0.0.0.0	passport-us.bignox.com
+0.0.0.0	passport.yeshen.com
+0.0.0.0	pasta.esfile.duapps.com
+0.0.0.0	pay.bignox.com
+0.0.0.0	pay.yeshen.com
+0.0.0.0	ph.bignox.com
+0.0.0.0	phone.bignox.com
+0.0.0.0	plat-api.bignox.com
+0.0.0.0	player.bignox.com
+0.0.0.0	pl.bignox.com
+0.0.0.0	pop3.bignox.com
+0.0.0.0	pt.bignox.com
+0.0.0.0	pubstatus.sinaapp.com
+0.0.0.0	res02.bignox.com
+0.0.0.0	res02.noxgroup.com
+0.0.0.0	res05.bignox.com
+0.0.0.0	res05.noxgroup.com
+0.0.0.0	res06.bignox.com
+0.0.0.0	res06.noxgroup.com
+0.0.0.0	res09.bignox.com
+0.0.0.0	res09.noxgroup.com
+0.0.0.0	res11.bignox.com
+0.0.0.0	res11.noxgroup.com
+0.0.0.0	res12.bignox.com
+0.0.0.0	res12.noxgroup.com
+0.0.0.0	res.bignox.com
+0.0.0.0	res.noxmobi.com
+0.0.0.0	ru.bignox.com
+0.0.0.0	sdk.bignox.com
+0.0.0.0	sdk.open.inc2.igexin.com
+0.0.0.0	shouyou.bignox.com
+0.0.0.0	sj.bignox.com
+0.0.0.0	sns.bignox.com
+0.0.0.0	st.bignox.com
+0.0.0.0	support.bignox.com
+0.0.0.0	support.yeshen.com
+0.0.0.0	survey.bignox.com
+0.0.0.0	t.bignox.com
+0.0.0.0	tdcv3.talkingdata.net
+0.0.0.0	test.bignox.com
+0.0.0.0	th.bignox.com
+0.0.0.0	tl.bignox.com
+0.0.0.0	tracking.apptrackerlink.com
+0.0.0.0	tracking.trnox.com
+0.0.0.0	tr.bignox.com
+0.0.0.0	tui.bignox.com
+0.0.0.0	tv.bignox.com
+0.0.0.0	tw.bignox.com
+0.0.0.0	unauthorized.bignox.com
+0.0.0.0	union.bignox.com
+0.0.0.0	user.bignox.com
+0.0.0.0	vip.bignox.com
+0.0.0.0	vn.bignox.com
+0.0.0.0	wap.bignox.com
+0.0.0.0	www.bignox.com
+0.0.0.0	www.noxgroup.com
+0.0.0.0	www.yeshen.com
+0.0.0.0	www.yeshen.com.w.kunlungr.com
+0.0.0.0	yeshen.com
+# END HOSTS LIST ### DO NOT EDIT THIS LINE AT ALL ###


### PR DESCRIPTION
Adding a block list for Nox likely refers to adding a list of domains, URLs, or IP addresses to block ads, pop-ups, or other unwanted content in the Nox emulator or app. This is done to improve the user experience by reducing distractions and improving performance.