### PR TITLE
Exclude localhost.localdomain

### DIFF
--- a/filters/general/filter_33_StevenBlack/configuration.json
+++ b/filters/general/filter_33_StevenBlack/configuration.json
@@ -9,7 +9,10 @@
             "type": "hosts",
             "transformations": [
                 "Validate"
-            ]
+            ],
+            "exclusions": [
+		        "localhost.localdomain"
+		    ]
         }
     ],
     "transformations": [


### PR DESCRIPTION
I noticed in the steven black hosts that the 127.0.0.1 localhost.localdomain is present at the top of the list. Not sure if this was expected to be deleted from the list or not though.