### PR TITLE
DEV env: Switch from HaGeZi Personal to HaGeZi Multi Normal

### DIFF
--- a/assets/filters-dev.json
+++ b/assets/filters-dev.json
@@ -99,8 +99,8 @@
 		{
 			"filterId": "hagezi_personal",
 			"id": 34,
-			"name": "HaGeZi Personal Black & White",
-			"description": "An extension for existing blocklists, my personal black and whitelist. Unblocks false positives and referral domains.",
+			"name": "HaGeZi - Multi NORMAL",
+			"description": "Broom - Cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
 			"tags": [
 				"purpose:general"
 			],
@@ -108,7 +108,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_34.txt",
-			"sourceUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/personal-blackwhite.txt",
+			"sourceUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/multi.txt",
 			"timeAdded": 1667987017479,
 			"timeUpdated": 1688461533936
 		},


### PR DESCRIPTION
I have replaced the contents of the Personal with the contents of the Multi NORMAL. This contains all my personal non-aggressive blocklists and extensions.

I have adjusted the name, description and retrieval link accordingly.

Thank you,
Gerd