### PR TITLE
Add EN locale for EasyList Hebrew

### DIFF
--- a/locales/en/filters.json
+++ b/locales/en/filters.json
@@ -162,5 +162,9 @@
 	{
 		"hostlist.42.name": "ShadowWhisperer's Malware List",
 		"hostlist.42.description": "Malicious Sites, PUPs, Malware, Browser Hijackers, Phishing Sites"
+	},
+	{
+		"hostlist.43.name": "ISR: EasyList Hebrew",
+		"hostlist.43.description": "List for blocking ads in Hebrew."
 	}
 ]


### PR DESCRIPTION
It was forgotten here:
https://github.com/AdguardTeam/HostlistsRegistry/pull/233
