### PR TITLE
AWAvenue-Adblock-Rule

### DIFF
--- a/assets/filters.json
+++ b/assets/filters.json
@@ -800,6 +800,23 @@
 			"sourceUrl": "https://raw.githubusercontent.com/mitchellkrogza/The-Big-List-of-Hacked-Malware-Web-Sites/master/hosts",
 			"timeAdded": 1622639343000,
 			"timeUpdated": 1688122411722
+		},
+				{
+			"filterId": "AWAvenue-Adblock-Rule",
+			"id": 53,
+			"name": "-AWAvenue 秋风广告规则 -",
+			"description": "干掉所有无良广告sdk | Eliminate All Malicious Ads sdk",
+			"tags": [
+				"purpose:regional",
+				"lang:zh"
+			],
+			"homepage": "https://github.com/TG-Twilight/AWAvenue-Adblock-Rule",
+			"expires": 345600,
+			"displayNumber": 4,
+			"downloadUrl": "",
+			"sourceUrl": "https://raw.githubusercontent.com/TG-Twilight/AWAvenue-Adblock-Rule/main/AWAvenue-Adblock-Rule.txt"，
+			"timeAdded": ,
+			"timeUpdated": 
 		}
 	],
 	"tags": [


### PR DESCRIPTION
Mainly used to intercept advertising sdk in Chinese apps, designed specifically for AdGuard Home and AdGuard DNS.