### PR TITLE
Add max.com to hbomax service

### DIFF
--- a/services/hbomax.yml
+++ b/services/hbomax.yml
@@ -13,4 +13,5 @@ rules:
   - '||hbomaxcdn.com^'
   - '||hbonow.com^'
   - '||maxgo.com^'
+  - '||max.com^'
 icon_svg: <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 50 50"><path d="M0 14v22h5v-9h3v9h5V14H8v8H5v-8H0zm15 0v22h8.4c3.1 0 5.7-2.3 6.2-5.4a11 11 0 1 0 0-11.2c-.5-3-3-5.4-6.2-5.4H15zm5 5h3a2 2 0 1 1 0 4h-3v-4zm19 0a6 6 0 1 1 0 12 6 6 0 0 1 0-12zm0 2a4 4 0 0 0-4 4 4 4 0 0 0 4 4 4 4 0 0 0 4-4 4 4 0 0 0-4-4zm-11 2.8v2.4c-.4-.5-1-1-2-1.2 1-.3 1.7-.8 2-1.3zm-8 4h3a2 2 0 1 1 0 4h-3v-4z"/></svg>


### PR DESCRIPTION
https://github.com/AdguardTeam/HostlistsRegistry/issues/318

Max will be replacing HBO Max. It already has in the US.

https://www.hbo.com/hbo-and-max

After the migration is complete, we need to change the name of the service from hbomax to max. 
In the meantime, we can just add max.com to the list of domains.