### PR TITLE
fix #488 update CERT Polska source

### DIFF
--- a/filters/regional/filter_41_POL_CERTPolskaListOfMaliciousDomains/configuration.json
+++ b/filters/regional/filter_41_POL_CERTPolskaListOfMaliciousDomains/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
       {
         "name": "CERT Polska List of malicious domains",
-        "source": "https://hole.cert.pl/domains/domains_adblock.txt",
+        "source": "https://hole.cert.pl/domains/v2/domains_adblock.txt",
         "type": "adblock",
         "transformations": [
           "RemoveModifiers",


### PR DESCRIPTION
https://github.com/AdguardTeam/HostlistsRegistry/issues/488

"Now CERT created version 2.0. Differences become in size,on old version there was all bad domains,now in version 2.0 are included domains that was used in last 6 months so size will decrease."