### PR TITLE
Added trusted flag to the filters registry

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "program": "${workspaceFolder}/index.js"
+            "program": "${workspaceFolder}/scripts/compose.js"
         },
         {
             "type": "pwa-node",

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The files `/assets/filters.json` and `/assets/filters-dev.json` must not be edit
   - `environment` - either `dev` or `prod`. Only `prod` lists are available in AdGuard DNS.
   - `disabled` - if set to `true`, the blocklist won't be updated.
   - `tags` — a list of [tags](#tags)
+  - `trusted` - a flag that allows using `$dnsrewrite` rules for this filter. If the filter is not trusted, `$dnsrewrite` rules will be removed from the compiled filter.
 
     <details>
       <summary>Metadata example</summary>
@@ -86,7 +87,8 @@ The files `/assets/filters.json` and `/assets/filters-dev.json` must not be edit
     "expires": "4 days",
     "displayNumber": 3,
     "environment": "prod",
-    "tags": []
+    "tags": [],
+    "trusted": true
   }
   ```
 

--- a/filters/general/filter_1_DnsFilter/metadata.json
+++ b/filters/general/filter_1_DnsFilter/metadata.json
@@ -11,5 +11,6 @@
   "environment": "prod",
   "tags": [
     "purpose:general"
-  ]
+  ],
+  "trusted": true
 }

--- a/filters/general/filter_59_DnsPopupsFilter/metadata.json
+++ b/filters/general/filter_59_DnsPopupsFilter/metadata.json
@@ -11,5 +11,6 @@
   "environment": "prod",
   "tags": [
     "purpose:general"
-  ]
+  ],
+  "trusted": true
 }

--- a/hostlists-builder/index.js
+++ b/hostlists-builder/index.js
@@ -175,10 +175,17 @@ async function build(filtersDir, tagsDir, localesDir, assetsDir, groupsDir) {
         revision.setVersionCandidate();
         revision.setTimeUpdatedCandidate();
 
-        const hostlistCompiled = await hostlistCompiler({
+        let hostlistCompiled = await hostlistCompiler({
           ...hostlistConfiguration,
           version: revision.getVersionCandidate(),
         });
+
+        if (!metadata.trusted) {
+          // Remove $dnsrewrite rules if the filter is not trusted.
+          hostlistCompiled = hostlistCompiled.filter((line) => {
+            return !line.includes('dnsrewrite');
+          });
+        }
 
         const hash = calculateRevisionHash(hostlistCompiled);
 

--- a/hostlists-builder/index.js
+++ b/hostlists-builder/index.js
@@ -183,7 +183,7 @@ async function build(filtersDir, tagsDir, localesDir, assetsDir, groupsDir) {
         if (!metadata.trusted) {
           // Remove $dnsrewrite rules if the filter is not trusted.
           hostlistCompiled = hostlistCompiled.filter((line) => {
-            return !line.includes('dnsrewrite');
+            return !line.includes('dnsrewrite=');
           });
         }
 


### PR DESCRIPTION
This PR adds an optional `trusted` flag to the list metadata.

If `trusted` is set to `true` we allow `dnsrewrite` rules for the list.
If it is not set to `true`, these rules are automatically removed from the list.