### PR TITLE
Fix AdGuardDNS/issues/759 startpage.com safesearch

### DIFF
--- a/assets/engines_safe_search.txt
+++ b/assets/engines_safe_search.txt
@@ -211,6 +211,8 @@
 # Pixabay
 |pixabay.com^$dnsrewrite=NOERROR;CNAME;safesearch.pixabay.com
 #
+! Startpage
+|www.startpage.com^$dnsrewrite=NOERROR;CNAME;safe.startpage.com
 # Qwant
 |api.qwant.com^$dnsrewrite=NOERROR;CNAME;safeapi.qwant.com
 #


### PR DESCRIPTION
https://github.com/AdguardTeam/AdGuardDNS/issues/759

In the `nslookup` response, I see applying, but Safe Mode can be disabled

<details>
<summary>Details</summary>

![image](https://github.com/user-attachments/assets/f2b9bba5-e641-4812-92bb-8a85304b53e0)


</details>

### **Don't merge until the problem is solved.**