### PR TITLE
Update hostlist-compiler to 1.0.34 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@adguard/hostlist-compiler": "^1.0.29",
+    "@adguard/hostlist-compiler": "^1.0.34",
     "chalk": "^4.0.0",
     "dayjs": "^1.11.11",
     "js-yaml": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adguard/hostlist-compiler@^1.0.29":
-  version "1.0.29"
-  resolved "https://registry.yarnpkg.com/@adguard/hostlist-compiler/-/hostlist-compiler-1.0.29.tgz#838b79fe332e6fc7e52447740f5c4673a3567195"
-  integrity sha512-6psnrT9unsgjvU04ph3UWlKT4xDZRb5MGvyvdPEH7zppvWFf+CieFuCWYUHbiUGepFRkzrlc7QMPdv14dPiQyQ==
+"@adguard/hostlist-compiler@^1.0.34":
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/@adguard/hostlist-compiler/-/hostlist-compiler-1.0.34.tgz#81d0e4e71c9d007185ccea26c931fe92f7afb055"
+  integrity sha512-JRsB4Jn1KwbrsU6k5qEUP/oUg0fY2KDklUbLEYI/qLQgxiD2iLpsBVE1Ans8c76zc9T1geCsoexpkJsHl9+b5g==
   dependencies:
     ajv "^6.12.0"
     ajv-errors "^1.0.1"


### PR DESCRIPTION
Done: https://github.com/AdguardTeam/HostlistCompiler/issues/63
Reverted: https://github.com/AdguardTeam/HostlistCompiler/issues/76