### PR TITLE
added hagezi multi pro++ mini

### DIFF
--- a/filters/general/filter_65_HageziMultiPro++Mini/configuration.json
+++ b/filters/general/filter_65_HageziMultiPro++Mini/configuration.json
@@ -1,0 +1,21 @@
+{
+    "name": "HaGeZi's Multi PRO++ mini",
+    "description": "Size-optimised version for DNS/Browser adblockers. This list only contains domains from the Pro++ full that have been found on Top 1M lists in the last 12 months.",
+    "homepage": "https://github.com/hagezi/dns-blocklists",
+    "sources": [
+      {
+        "name": "HaGeZi's Multi PRO++ mini",
+        "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/pro.plus.mini.txt",
+        "type": "adblock",
+        "transformations": [
+          "RemoveModifiers",
+          "Validate"
+        ]
+      }
+    ],
+    "transformations": [
+      "RemoveComments",
+      "Deduplicate",
+      "Compress"
+    ]
+}

--- a/filters/general/filter_65_HageziMultiPro++Mini/metadata.json
+++ b/filters/general/filter_65_HageziMultiPro++Mini/metadata.json
@@ -1,0 +1,15 @@
+{
+    "filterKey": "hagezi_multi_pro++_mini",
+    "filterId": 65,
+    "groupId": 1,
+    "name": "HaGeZi's Multi PRO++ mini",
+    "description": "Size-optimised version for DNS/Browser adblockers. This list only contains domains from the Pro++ full that have been found on Top 1M lists in the last 12 months.",
+    "timeAdded": 1740614235292,
+    "homepage": "https://github.com/hagezi/dns-blocklists",
+    "expires": "4 days",
+    "displayNumber": 4,
+    "environment": "prod",
+    "tags": [
+      "purpose:general"
+    ]
+}

--- a/locales/en/filters.json
+++ b/locales/en/filters.json
@@ -217,5 +217,9 @@
 	},
 	{
 		"hostlist.60.description": "Blocks Xiaomi native broadband trackers that track your activity."
+	},
+	{
+		"hostlist.65.name": "HaGeZi's Multi PRO++ mini",
+		"hostlist.65.description": "Size-optimised version for DNS/Browser adblockers. This list only contains domains from the Pro++ full that have been found on Top 1M lists in the last 12 months."
 	}
 ]


### PR DESCRIPTION
Size-optimised version for DNS/Browser adblockers. This list only contains domains from the Pro++ full that have been found on Top 1M lists in the last 12 months.