### PR TITLE
Add Japan Youth Restricted Filter

### DIFF
--- a/filters/regional/filter_65_JPN_Youth_Restricted/configuration.json
+++ b/filters/regional/filter_65_JPN_Youth_Restricted/configuration.json
@@ -1,0 +1,13 @@
+{
+    "name": "Japan Youth Restricted Filter",
+    "description": "FIt contains a blacklist of content considered inappropriate for young people in Japan; restricts inappropriate content on LINE and Yahoo searches.",
+    "homepage": "https://github.com/matsuhiro/AdGuardFilters",
+    "sources": [
+      {
+        "name": "Japan Youth Restricted Filter",
+        "url": "https://raw.githubusercontent.com/matsuhiro/AdGuardFilters/refs/heads/main/output/all_filters.txt",
+        "format": "hosts"
+      }
+    ],
+    "transformations": []
+}

--- a/filters/regional/filter_65_JPN_Youth_Restricted/configuration.json
+++ b/filters/regional/filter_65_JPN_Youth_Restricted/configuration.json
@@ -1,6 +1,6 @@
 {
     "name": "Japan Youth Restricted Filter",
-    "description": "FIt contains a blacklist of content considered inappropriate for young people in Japan; restricts inappropriate content on LINE and Yahoo searches.",
+    "description": "It contains a blacklist of content considered inappropriate for young people in Japan; restricts inappropriate content on LINE and Yahoo searches.",
     "homepage": "https://github.com/matsuhiro/AdGuardFilters",
     "sources": [
       {

--- a/filters/regional/filter_65_JPN_Youth_Restricted/metadata.json
+++ b/filters/regional/filter_65_JPN_Youth_Restricted/metadata.json
@@ -1,0 +1,13 @@
+{
+    "filterKey": "japan_youth_restricted_filter",
+    "filterId": 65,
+    "name": "Japan Youth Restricted Filter",
+    "description": "It contains a blacklist of content considered inappropriate for young people in Japan; restricts inappropriate content on LINE and Yahoo searches.",
+    "timeAdded": 1745758749000,
+    "homepage": "https://raw.githubusercontent.com/matsuhiro/AdGuardFilters/refs/heads/main/output/all_filters.txt",
+    "expires": "4 days",
+    "displayNumber": 100,
+    "environment": "prod",
+    "tags": ["purpose:ads","purpose:tracking"],
+    "trusted": false
+  }

--- a/locales/en/filters.json
+++ b/locales/en/filters.json
@@ -234,5 +234,9 @@
 	{
 		"hostlist.64.name": "1Hosts (Pro)",
 		"hostlist.64.description": "List for blocking annoying ads, trackers, and malware. Strict version: has minimal breaks, prioritizes privacy and security (ad blocking) over UX, e.g. blocks `graph.facebook.com`."
+	},
+	{
+		"hostlist.65.name": "Japan Youth Restricted Filter",
+		"hostlist.65.description": "It contains a blacklist of content considered inappropriate for young people in Japan; restricts inappropriate content on LINE and Yahoo searches."
 	}
 ]


### PR DESCRIPTION
This PR proposes the inclusion of matsuhiro's all_filters.txt as a new hostlist.

Filters content and forums considered inappropriate for young people in Japan.
Yahoo Japan search is filtered because safe mode does not exist.
Inappropriate content within LINE, which is popular in Japan, is also filtered.