### PR TITLE
Enable "41 POL: CERT Polska List of malicious domains"

### DIFF
--- a/filters/regional/filter_41_POL_CERTPolskaListOfMaliciousDomains/metadata.json
+++ b/filters/regional/filter_41_POL_CERTPolskaListOfMaliciousDomains/metadata.json
@@ -12,6 +12,5 @@
     "tags": [
       "purpose:regional",
       "lang:pl"
-    ],
-    "disabled": true
+    ]
   }


### PR DESCRIPTION
Reverts AdguardTeam/HostlistsRegistry#656

Check when the filter will be available for GitHub again.