### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/scripts/services/merge-services-data.js
+++ b/scripts/services/merge-services-data.js
@@ -16,10 +16,10 @@ const { sortByKey } = require('../helpers/helpers');
  */
 const mergeServicesData = (distServices, sourceServices) => {
     const mergedMap = [...distServices, ...sourceServices].reduce((acc, obj) => {
-        acc[obj.id] = obj;
+        acc.set(obj.id, obj);
         return acc;
-    }, {});
-    return Object.values(mergedMap);
+    }, new Map());
+    return Array.from(mergedMap.values());
 };
 
 /**

--- a/scripts/services/restore-removed-services.js
+++ b/scripts/services/restore-removed-services.js
@@ -5,6 +5,7 @@ const { logger } = require('../helpers/logger');
 const { serviceSchema } = require('./zod-schemas');
 
 const YML_FILE_EXTENSION = '.yml';
+const SERVICE_ID_PATTERN = /^[a-z0-9_-]+$/;
 
 /**
  * @typedef {require('./type-defs').Service} Service
@@ -24,12 +25,26 @@ const restoreRemovedSourceFiles = async (differences, sourceDirPath) => {
     const [removedObject, ...restObjects] = differences;
     serviceSchema.parse(removedObject);
 
+    if (!SERVICE_ID_PATTERN.test(removedObject.id)) {
+        throw new Error(`Invalid service id: ${removedObject.id}`);
+    }
+
+    const resolvedSourceDirPath = path.resolve(sourceDirPath);
+    const outputFilePath = path.resolve(sourceDirPath, `${removedObject.id}${YML_FILE_EXTENSION}`);
+    const sourceDirPrefix = resolvedSourceDirPath.endsWith(path.sep)
+        ? resolvedSourceDirPath
+        : `${resolvedSourceDirPath}${path.sep}`;
+
+    if (!outputFilePath.startsWith(sourceDirPrefix)) {
+        throw new Error(`Invalid service file path: ${outputFilePath}`);
+    }
+
     await fs.writeFile(
-        path.join(`${sourceDirPath}/${removedObject.id}${YML_FILE_EXTENSION}`),
+        outputFilePath,
         yaml.dump(removedObject, { lineWidth: -1 }),
     );
     if (sourceDirPath.length > 1) {
-        await restoreRemovedSourceFiles(restObjects);
+        await restoreRemovedSourceFiles(restObjects, sourceDirPath);
     }
     const removedServices = differences.map((difference) => difference.id);
     logger.warn(`These services have been removed: ${removedServices.join(', ')}, and were restored`);


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `scripts/services/restore-removed-services.js:L26`

When restoring removed services, the output file path is built using `removedObject.id` directly. Because `serviceSchema` only enforces `id` as a string (no path-safe pattern), an `id` like `../../.github/workflows/pwn` could cause writes outside `sourceDirPath` during build execution.

## Solution

Validate `removedObject.id` against a strict allowlist regex (e.g. `^[a-z0-9_-]+$`), build paths with `path.resolve(sourceDirPath, ...)`, and enforce that the resolved path starts with the resolved `sourceDirPath` before writing.

## Changes

- `scripts/services/restore-removed-services.js` (modified)
- `scripts/services/merge-services-data.js` (modified)