### PR TITLE
fix: add exclude field to typosquatting allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ The file format is JSON:
 ```json
 {
   "exclude": [
-    "example-*.com"
+    "example-*.com",
+    "test.com"
   ],
   "domains": [
     {

--- a/README.md
+++ b/README.md
@@ -237,14 +237,20 @@ SVG icon requirements:
 
 ## <a id="typosquatting-allowlist"></a> Typosquatting Allowlist
 
-- [`typosquatting_allowlist.json`](https://adguardteam.github.io/HostlistsRegistry/assets/typosquatting_allowlist.json) contains domain-specific exceptions for the Typosquatting protection feature in AdGuard Private DNS.
-- This file is used as an allowlist for legitimate domains that may look like typos or homograph variants of protected popular domains and therefore must not be treated as suspicious.
-- The protected domains dataset itself is built in a different pipeline. This repository stores only the exception list maintained for that feature.
+- [`typosquatting_allowlist.json`](https://adguardteam.github.io/HostlistsRegistry/assets/typosquatting_allowlist.json)
+contains exclusions and domain-specific exceptions for the Typosquatting protection feature in AdGuard Private DNS.
+- This file is used as an allowlist for legitimate domains that may look like typos or homograph variants of protected
+popular domains and therefore must not be treated as suspicious and for excluding protected domains from the check.
+- The protected domains dataset itself is built in a different pipeline. This repository stores only the exception and
+exclusion list maintained for that feature.
 
 The file format is JSON:
 
 ```json
 {
+  "exclude": [
+    "example-*.com"
+  ],
   "domains": [
     {
       "domain": "discovery.com",
@@ -254,18 +260,30 @@ The file format is JSON:
 }
 ```
 
-Each entry has:
+### `exclude`
+
+An array of domain patterns (supports glob-style `*` wildcards) that should be completely excluded from the protected
+domains dataset.
+
+If a domain matches an entry in `exclude`, it will not be sent to the DNS server and will not be checked for
+typosquatting at all.
+
+### `domains`
+
+An array of per-domain exception entries. Each entry has:
 
 - `domain` — the protected domain, preferably in normalized eTLD+1 form.
 - `exceptions` — a list of domains that are explicitly allowed for this protected domain.
 
-How to work with this file:
+### How to work with this file
 
-1. Add or update an entry in the `domains` array in `typosquatting_allowlist.json`
-1. Set `domain` to the protected domain for which an exception is needed.
-1. Set the `exceptions` array to the list of exception domains.
-1. Submit a PR for review
-1. After merge, the exceptions will be applied on the next scheduled build
+1. Open `typosquatting_allowlist.json`.
+1. To **exclude** a protected domain pattern completely, add it to the `exclude` array.
+1. To add per-domain exceptions, add or update an entry in the `domains` array:
+   - Set `domain` to the protected domain.
+   - Set `exceptions` to the list of allowed lookalike domains.
+1. Submit a PR for review.
+1. After merge, the changes will be applied on the next scheduled build.
 
 ## <a id="how-to-build"></a> How to Build
 

--- a/README.md
+++ b/README.md
@@ -260,20 +260,15 @@ The file format is JSON:
 }
 ```
 
-**`exclude`**
+- **`exclude`**
+  - An array of domain patterns (supports glob-style `*` wildcards) that should be completely excluded from the protected domains dataset.  
+    If a domain matches an entry in `exclude`, it will not be sent to the DNS server and will not be checked for typosquatting at all.
 
-An array of domain patterns (supports glob-style `*` wildcards) that should be completely excluded from the protected
-domains dataset.
+- **`domains`**
+  - An array of per-domain exception entries. Each entry has:
 
-If a domain matches an entry in `exclude`, it will not be sent to the DNS server and will not be checked for
-typosquatting at all.
-
-**`domains`**
-
-An array of per-domain exception entries. Each entry has:
-
-- `domain` — the protected domain, preferably in normalized eTLD+1 form.
-- `exceptions` — a list of domains that are explicitly allowed for this protected domain.
+    - `domain` — the protected domain, preferably in normalized eTLD+1 form.
+    - `exceptions` — a list of domains that are explicitly allowed for this protected domain.
 
 ### How to work with this file
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The file format is JSON:
 }
 ```
 
-### `exclude`
+**`exclude`**
 
 An array of domain patterns (supports glob-style `*` wildcards) that should be completely excluded from the protected
 domains dataset.
@@ -268,7 +268,7 @@ domains dataset.
 If a domain matches an entry in `exclude`, it will not be sent to the DNS server and will not be checked for
 typosquatting at all.
 
-### `domains`
+**`domains`**
 
 An array of per-domain exception entries. Each entry has:
 
@@ -278,7 +278,7 @@ An array of per-domain exception entries. Each entry has:
 ### How to work with this file
 
 1. Open `typosquatting_allowlist.json`.
-1. To **exclude** a protected domain pattern completely, add it to the `exclude` array.
+1. To exclude a protected domain pattern completely, add it to the `exclude` array.
 1. To add per-domain exceptions, add or update an entry in the `domains` array:
    - Set `domain` to the protected domain.
    - Set `exceptions` to the list of allowed lookalike domains.

--- a/assets/typosquatting_allowlist.json
+++ b/assets/typosquatting_allowlist.json
@@ -1,4 +1,5 @@
 ﻿{
+  "exclude": [],
   "domains": [
     {
       "domain": "ahcdn.com",


### PR DESCRIPTION
- Add "exclude" array to typosquatting_allowlist.json for domain
  patterns that should be excluded from the protected domains set
- Document the field and update usage instructions in README