### PR TITLE
Added domains `dngroup.com`, `galp.com` to whitelist

### DIFF
--- a/assets/typosquatting_allowlist.json
+++ b/assets/typosquatting_allowlist.json
@@ -50,6 +50,10 @@
       "exceptions": [ "dngroup.com" ]
     },
     {
+      "domain": "gap.com",
+      "exceptions": [ "galp.com" ]
+    },
+    {
       "domain": "gtimg.com",
       "exceptions": [ "etimg.com" ]
     },

--- a/assets/typosquatting_allowlist.json
+++ b/assets/typosquatting_allowlist.json
@@ -46,6 +46,10 @@
       "exceptions": [ "discover.com" ]
     },
     {
+      "domain": "dvgroup.com",
+      "exceptions": [ "dngroup.com" ]
+    },
+    {
       "domain": "gtimg.com",
       "exceptions": [ "etimg.com" ]
     },


### PR DESCRIPTION
Related to
https://github.com/AdguardTeam/AdguardFilters/issues/233630
https://github.com/AdguardTeam/AdguardFilters/issues/233628.
Another issue https://github.com/AdguardTeam/AdguardFilters/issues/233629.