### PR TITLE
fix: switch HaGeZi blocklist sources from ctif.hagezi.org to GitHub raw URLs

### DIFF
--- a/assets/filters-dev.json
+++ b/assets/filters-dev.json
@@ -96,7 +96,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_34.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/multi.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/multi.txt",
 			"timeAdded": "2023-07-14T12:53:26+0000",
 			"timeUpdated": "2026-06-28T14:39:45+0000"
 		},
@@ -136,7 +136,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_48.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/pro.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/pro.txt",
 			"timeAdded": "2023-09-18T16:43:30+0000",
 			"timeUpdated": "2026-06-28T14:39:49+0000"
 		},
@@ -157,7 +157,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_49.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/ultimate.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/ultimate.txt",
 			"timeAdded": "2023-09-18T16:53:47+0000",
 			"timeUpdated": "2026-06-28T14:39:52+0000"
 		},
@@ -198,7 +198,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_51.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/pro.plus.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/pro.plus.txt",
 			"timeAdded": "2023-10-13T16:27:45+0000",
 			"timeUpdated": "2026-06-28T14:39:56+0000"
 		},
@@ -359,7 +359,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_45.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/whitelist-referral.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/whitelist-referral.txt",
 			"timeAdded": "2023-08-16T15:55:29+0000",
 			"timeUpdated": "2026-06-18T15:13:14+0000"
 		},
@@ -379,7 +379,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_46.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/anti.piracy.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/anti.piracy.txt",
 			"timeAdded": "2023-08-16T16:55:47+0000",
 			"timeUpdated": "2026-06-28T14:40:11+0000"
 		},
@@ -399,7 +399,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_47.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/gambling.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/gambling.txt",
 			"timeAdded": "2023-08-16T23:23:33+0000",
 			"timeUpdated": "2026-06-28T14:40:12+0000"
 		},
@@ -439,7 +439,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_60.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.xiaomi.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.xiaomi.txt",
 			"timeAdded": "2024-06-18T15:01:28+0000",
 			"timeUpdated": "2026-06-26T19:38:14+0000"
 		},
@@ -459,7 +459,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_61.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.samsung.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.samsung.txt",
 			"timeAdded": "2024-10-07T15:50:22+0000",
 			"timeUpdated": "2026-06-12T19:44:59+0000"
 		},
@@ -479,7 +479,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_63.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.winoffice.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.winoffice.txt",
 			"timeAdded": "2024-10-09T17:03:02+0000",
 			"timeUpdated": "2026-06-26T19:38:14+0000"
 		},
@@ -499,7 +499,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_65.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.vivo.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.vivo.txt",
 			"timeAdded": "2025-07-02T16:03:57+0000",
 			"timeUpdated": "2026-06-26T19:38:14+0000"
 		},
@@ -519,7 +519,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_66.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.oppo-realme.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.oppo-realme.txt",
 			"timeAdded": "2025-07-02T16:13:08+0000",
 			"timeUpdated": "2026-05-24T18:31:01+0000"
 		},
@@ -539,7 +539,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_67.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.apple.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.apple.txt",
 			"timeAdded": "2025-07-02T16:51:37+0000",
 			"timeUpdated": "2026-06-20T11:43:54+0000"
 		},
@@ -1116,7 +1116,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_44.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/tif.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/tif.txt",
 			"timeAdded": "2023-08-16T11:51:09+0000",
 			"timeUpdated": "2026-06-28T14:40:32+0000"
 		},
@@ -1156,7 +1156,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_52.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/doh-vpn-proxy-bypass.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/doh-vpn-proxy-bypass.txt",
 			"timeAdded": "2023-10-25T11:19:42+0000",
 			"timeUpdated": "2026-06-28T14:40:50+0000"
 		},
@@ -1176,7 +1176,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_54.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/dyndns.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/dyndns.txt",
 			"timeAdded": "2023-12-21T18:21:57+0000",
 			"timeUpdated": "2026-06-22T16:38:47+0000"
 		},
@@ -1196,7 +1196,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_55.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/hoster.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/hoster.txt",
 			"timeAdded": "2024-03-13T16:43:33+0000",
 			"timeUpdated": "2026-06-25T08:37:05+0000"
 		},
@@ -1217,7 +1217,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_56.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/spam-tlds.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/spam-tlds.txt",
 			"timeAdded": "2024-03-13T16:54:56+0000",
 			"timeUpdated": "2026-06-28T14:40:52+0000"
 		},
@@ -1237,7 +1237,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_68.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/urlshortener.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/urlshortener.txt",
 			"timeAdded": "2025-07-16T11:05:19+0000",
 			"timeUpdated": "2026-06-28T14:40:52+0000"
 		},
@@ -1257,7 +1257,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_71.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adguard/dns-rebind-protection.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adguard/dns-rebind-protection.txt",
 			"timeAdded": "2025-09-10T13:50:31+0000",
 			"timeUpdated": "2026-05-26T13:15:16+0000"
 		},

--- a/assets/filters.json
+++ b/assets/filters.json
@@ -96,7 +96,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_34.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/multi.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/multi.txt",
 			"timeAdded": "2023-07-14T12:53:26+0000",
 			"timeUpdated": "2026-06-28T14:39:45+0000"
 		},
@@ -136,7 +136,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_48.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/pro.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/pro.txt",
 			"timeAdded": "2023-09-18T16:43:30+0000",
 			"timeUpdated": "2026-06-28T14:39:49+0000"
 		},
@@ -157,7 +157,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_49.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/ultimate.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/ultimate.txt",
 			"timeAdded": "2023-09-18T16:53:47+0000",
 			"timeUpdated": "2026-06-28T14:39:52+0000"
 		},
@@ -198,7 +198,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_51.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/pro.plus.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/pro.plus.txt",
 			"timeAdded": "2023-10-13T16:27:45+0000",
 			"timeUpdated": "2026-06-28T14:39:56+0000"
 		},
@@ -359,7 +359,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_45.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/whitelist-referral.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/whitelist-referral.txt",
 			"timeAdded": "2023-08-16T15:55:29+0000",
 			"timeUpdated": "2026-06-18T15:13:14+0000"
 		},
@@ -379,7 +379,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_46.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/anti.piracy.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/anti.piracy.txt",
 			"timeAdded": "2023-08-16T16:55:47+0000",
 			"timeUpdated": "2026-06-28T14:40:11+0000"
 		},
@@ -399,7 +399,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_47.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/gambling.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/gambling.txt",
 			"timeAdded": "2023-08-16T23:23:33+0000",
 			"timeUpdated": "2026-06-28T14:40:12+0000"
 		},
@@ -439,7 +439,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_60.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.xiaomi.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.xiaomi.txt",
 			"timeAdded": "2024-06-18T15:01:28+0000",
 			"timeUpdated": "2026-06-26T19:38:14+0000"
 		},
@@ -459,7 +459,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_61.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.samsung.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.samsung.txt",
 			"timeAdded": "2024-10-07T15:50:22+0000",
 			"timeUpdated": "2026-06-12T19:44:59+0000"
 		},
@@ -479,7 +479,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_63.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.winoffice.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.winoffice.txt",
 			"timeAdded": "2024-10-09T17:03:02+0000",
 			"timeUpdated": "2026-06-26T19:38:14+0000"
 		},
@@ -499,7 +499,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_65.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.vivo.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.vivo.txt",
 			"timeAdded": "2025-07-02T16:03:57+0000",
 			"timeUpdated": "2026-06-26T19:38:14+0000"
 		},
@@ -519,7 +519,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_66.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.oppo-realme.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.oppo-realme.txt",
 			"timeAdded": "2025-07-02T16:13:08+0000",
 			"timeUpdated": "2026-05-24T18:31:01+0000"
 		},
@@ -539,7 +539,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_67.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/native.apple.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.apple.txt",
 			"timeAdded": "2025-07-02T16:51:37+0000",
 			"timeUpdated": "2026-06-20T11:43:54+0000"
 		},
@@ -1116,7 +1116,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_44.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/tif.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/tif.txt",
 			"timeAdded": "2023-08-16T11:51:09+0000",
 			"timeUpdated": "2026-06-28T14:40:32+0000"
 		},
@@ -1156,7 +1156,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_52.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/doh-vpn-proxy-bypass.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/doh-vpn-proxy-bypass.txt",
 			"timeAdded": "2023-10-25T11:19:42+0000",
 			"timeUpdated": "2026-06-28T14:40:50+0000"
 		},
@@ -1176,7 +1176,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_54.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/dyndns.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/dyndns.txt",
 			"timeAdded": "2023-12-21T18:21:57+0000",
 			"timeUpdated": "2026-06-22T16:38:47+0000"
 		},
@@ -1196,7 +1196,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_55.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/hoster.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/hoster.txt",
 			"timeAdded": "2024-03-13T16:43:33+0000",
 			"timeUpdated": "2026-06-25T08:37:05+0000"
 		},
@@ -1217,7 +1217,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_56.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/spam-tlds.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/spam-tlds.txt",
 			"timeAdded": "2024-03-13T16:54:56+0000",
 			"timeUpdated": "2026-06-28T14:40:52+0000"
 		},
@@ -1237,7 +1237,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_68.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adblock/urlshortener.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/urlshortener.txt",
 			"timeAdded": "2025-07-16T11:05:19+0000",
 			"timeUpdated": "2026-06-28T14:40:52+0000"
 		},
@@ -1257,7 +1257,7 @@
 			"expires": 345600,
 			"displayNumber": 4,
 			"downloadUrl": "https://adguardteam.github.io/HostlistsRegistry/assets/filter_71.txt",
-			"subscriptionUrl": "https://ctif.hagezi.org/blocklists/adguard/dns-rebind-protection.txt",
+			"subscriptionUrl": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adguard/dns-rebind-protection.txt",
 			"timeAdded": "2025-09-10T13:50:31+0000",
 			"timeUpdated": "2026-05-26T13:15:16+0000"
 		},

--- a/filters/general/filter_34_HageziMultiNormal/configuration.json
+++ b/filters/general/filter_34_HageziMultiNormal/configuration.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "name": "HaGeZi's Normal Blocklist",
-      "source": "https://ctif.hagezi.org/blocklists/adblock/multi.txt",
+      "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/multi.txt",
       "type": "adblock",
       "transformations": [
         "RemoveModifiers",

--- a/filters/general/filter_48_HageziMultiPro/configuration.json
+++ b/filters/general/filter_48_HageziMultiPro/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
       {
         "name": "HaGeZi's Pro Blocklist",
-        "source": "https://ctif.hagezi.org/blocklists/adblock/pro.txt",
+        "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/pro.txt",
         "type": "adblock",
         "transformations": [
           "RemoveModifiers",

--- a/filters/general/filter_49_HageziUltimate/configuration.json
+++ b/filters/general/filter_49_HageziUltimate/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
       {
         "name": "HaGeZi's Ultimate Blocklist",
-        "source": "https://ctif.hagezi.org/blocklists/adblock/ultimate.txt",
+        "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/ultimate.txt",
         "type": "adblock",
         "transformations": [
           "RemoveModifiers",

--- a/filters/general/filter_51_HageziPro++/configuration.json
+++ b/filters/general/filter_51_HageziPro++/configuration.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "name": "HaGeZi's Pro++ Blocklist",
-      "source": "https://ctif.hagezi.org/blocklists/adblock/pro.plus.txt",
+      "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/pro.plus.txt",
       "type": "adblock",
       "transformations": [
         "RemoveModifiers",

--- a/filters/other/filter_45_HageziAllowlistReferal/configuration.json
+++ b/filters/other/filter_45_HageziAllowlistReferal/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
         {
             "name": "HaGeZi's Allowlist Referral",
-            "source": "https://ctif.hagezi.org/blocklists/adblock/whitelist-referral.txt",
+            "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/whitelist-referral.txt",
             "type": "adblock",
             "transformations": [
                 "RemoveModifiers",

--- a/filters/other/filter_46_HageziAntiPiracyBlocklist/configuration.json
+++ b/filters/other/filter_46_HageziAntiPiracyBlocklist/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
         {
             "name": "HaGeZi's Anti-Piracy Blocklist",
-            "source": "https://ctif.hagezi.org/blocklists/adblock/anti.piracy.txt",
+            "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/anti.piracy.txt",
             "type": "adblock",
             "transformations": [
                 "RemoveModifiers",

--- a/filters/other/filter_47_HageziGamblingBlocklist/configuration.json
+++ b/filters/other/filter_47_HageziGamblingBlocklist/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
         {
             "name": "HaGeZi's Gambling Blocklist",
-            "source": "https://ctif.hagezi.org/blocklists/adblock/gambling.txt",
+            "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/gambling.txt",
             "type": "adblock",
             "transformations": [
                 "RemoveModifiers",

--- a/filters/other/filter_60_HageziXiaomiTrackerBlocklist/configuration.json
+++ b/filters/other/filter_60_HageziXiaomiTrackerBlocklist/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
         {
             "name": "HaGeZi's Xiaomi Tracker Blocklist",
-            "source": "https://ctif.hagezi.org/blocklists/adblock/native.xiaomi.txt",
+            "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.xiaomi.txt",
             "type": "adblock",
             "transformations": [
                 "RemoveModifiers",

--- a/filters/other/filter_61_HageziSamsungTrackerBlocklist/configuration.json
+++ b/filters/other/filter_61_HageziSamsungTrackerBlocklist/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
         {
             "name": "HaGeZi's Samsung Tracker Blocklist",
-            "source": "https://ctif.hagezi.org/blocklists/adblock/native.samsung.txt",
+            "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.samsung.txt",
             "type": "adblock",
             "transformations": [
                 "RemoveModifiers",

--- a/filters/other/filter_63_HaGeZiWindowsOfficeTrackerBlocklist/configuration.json
+++ b/filters/other/filter_63_HaGeZiWindowsOfficeTrackerBlocklist/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
         {
             "name": "HaGeZi's Windows/Office Tracker Blocklist",
-            "source": "https://ctif.hagezi.org/blocklists/adblock/native.winoffice.txt",
+            "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.winoffice.txt",
             "type": "adblock",
             "transformations": [
                 "RemoveModifiers",

--- a/filters/other/filter_65_HageziVivoTrackerBlocklist/configuration.json
+++ b/filters/other/filter_65_HageziVivoTrackerBlocklist/configuration.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "name": "HaGeZi's Vivo Tracker Blocklist",
-      "source": "https://ctif.hagezi.org/blocklists/adblock/native.vivo.txt",
+      "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.vivo.txt",
       "type": "adblock",
       "transformations": [
           "RemoveModifiers",

--- a/filters/other/filter_66_HageziOppoRealmeTrackerBlocklist/configuration.json
+++ b/filters/other/filter_66_HageziOppoRealmeTrackerBlocklist/configuration.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "name": "HaGeZi's OPPO & Realme Tracker Blocklist",
-      "source": "https://ctif.hagezi.org/blocklists/adblock/native.oppo-realme.txt",
+      "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.oppo-realme.txt",
       "type": "adblock",
       "transformations": [
         "RemoveModifiers",

--- a/filters/other/filter_67_HageziAppleTrackerBlocklist/configuration.json
+++ b/filters/other/filter_67_HageziAppleTrackerBlocklist/configuration.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "name": "HaGeZi's Apple Tracker Blocklist",
-      "source": "https://ctif.hagezi.org/blocklists/adblock/native.apple.txt",
+      "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/native.apple.txt",
       "type": "adblock",
       "transformations": [
         "RemoveModifiers",

--- a/filters/security/filter_44_HageziThreatIntelligenceFeeds/configuration.json
+++ b/filters/security/filter_44_HageziThreatIntelligenceFeeds/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
       {
         "name": "HaGeZi's Threat Intelligence Feeds",
-        "source": "https://ctif.hagezi.org/blocklists/adblock/tif.txt",
+        "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/tif.txt",
         "type": "adblock",
         "transformations": [
           "RemoveModifiers",

--- a/filters/security/filter_52_HageziEncryptedDNSBypass/configuration.json
+++ b/filters/security/filter_52_HageziEncryptedDNSBypass/configuration.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "name": "HaGeZi's Encrypted DNS/VPN/TOR/Proxy Bypass",
-      "source": "https://ctif.hagezi.org/blocklists/adblock/doh-vpn-proxy-bypass.txt",
+      "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/doh-vpn-proxy-bypass.txt",
       "type": "adblock",
       "transformations": [
         "RemoveModifiers",

--- a/filters/security/filter_54_HageziDynDNSBlocklist/configuration.json
+++ b/filters/security/filter_54_HageziDynDNSBlocklist/configuration.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "name": "HaGeZi's DynDNS Blocklist",
-      "source": "https://ctif.hagezi.org/blocklists/adblock/dyndns.txt",
+      "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/dyndns.txt",
       "type": "adblock",
       "transformations": [
         "Validate"

--- a/filters/security/filter_55_HageziBadwareHosterBlocklist/configuration.json
+++ b/filters/security/filter_55_HageziBadwareHosterBlocklist/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
       {
         "name": "HaGeZi's Badware Hoster Blocklist",
-        "source": "https://ctif.hagezi.org/blocklists/adblock/hoster.txt",
+        "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/hoster.txt",
         "type": "adblock",
         "transformations": [
           "Validate"

--- a/filters/security/filter_56_HageziTheWorldsMostAbusedTLDs/configuration.json
+++ b/filters/security/filter_56_HageziTheWorldsMostAbusedTLDs/configuration.json
@@ -5,7 +5,7 @@
     "sources": [
       {
         "name": "HaGeZi's The World's Most Abused TLDs",
-        "source": "https://ctif.hagezi.org/blocklists/adblock/spam-tlds.txt",
+        "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/spam-tlds.txt",
         "type": "adblock",
       "transformations": [
         "ValidateAllowPublicSuffix"

--- a/filters/security/filter_68_HageziURLShortenerBlocklist/configuration.json
+++ b/filters/security/filter_68_HageziURLShortenerBlocklist/configuration.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "name": "HaGeZi's URL Shortener Blocklist",
-      "source": "https://ctif.hagezi.org/blocklists/adblock/urlshortener.txt",
+      "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/urlshortener.txt",
       "type": "adblock",
       "transformations": [
         "RemoveModifiers",

--- a/filters/security/filter_71_HageziDNSRebindProtection/configuration.json
+++ b/filters/security/filter_71_HageziDNSRebindProtection/configuration.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "name": "HaGeZi's DNS Rebind Protection",
-      "source": "https://ctif.hagezi.org/blocklists/adguard/dns-rebind-protection.txt",
+      "source": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adguard/dns-rebind-protection.txt",
       "type": "adblock",
       "transformations": [
         "RemoveModifiers",


### PR DESCRIPTION
## Summary

Replaced all 60 `ctif.hagezi.org` source URLs across 20 HaGeZi filter configurations and the two registry files (`filters.json`, `filters-dev.json`) with equivalent `raw.githubusercontent.com/hagezi/dns-blocklists/main/` URLs. The actual file paths within the hagezi/dns-blocklists repo are identical, so no filename changes were needed.

## Why

`ctif.hagezi.org` has been experiencing connectivity issues, causing filter downloads to fail. The same blocklists are published under the official `hagezi/dns-blocklists` GitHub repository at identical paths, providing a more reliable download source.

## Testing

- Verified all 20 replacement URLs exist at `raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/...` and `raw.githubusercontent.com/hagezi/dns-blocklists/main/adguard/...`
- Confirmed zero remaining references to `ctif.hagezi.org` in the repository