### PR TITLE
fix #867 mirror.fcix.net typosquatting false positive

### DIFF
--- a/assets/typosquatting_allowlist.json
+++ b/assets/typosquatting_allowlist.json
@@ -94,6 +94,10 @@
       "exceptions": [ "apteka.ru" ]
     },
     {
+      "domain": "fnix.net",
+      "exceptions": [ "fcix.net" ]
+    },
+    {
       "domain": "gap.com",
       "exceptions": [ "galp.com" ]
     },


### PR DESCRIPTION
https://github.com/AdguardTeam/HostlistsRegistry/issues/867